### PR TITLE
Add TBC shield enchants

### DIFF
--- a/lib/constants/tbc_constants.rb
+++ b/lib/constants/tbc_constants.rb
@@ -61,6 +61,17 @@ weapon_enchants = {
 
 }
 
+shield_enchants = {
+  1071 => [4, "Major Stamina"],
+  1888 => [3, "Resistance"],
+  2653 => [4, "Tough Shield"],
+  2654 => [4, "Intellect"],
+  2655 => [4, "Shield Block"],
+  3229 => [4, "Resilience"],
+}
+
+off_hand_enchants = weapon_enchants.merge(shield_enchants)
+
 ring_enchants = {
   2930 => [4, "Healing Power"],
   2928 => [4, "Spellpower"],
@@ -166,7 +177,7 @@ TBC_ENCHANTS = {
   'finger_1' => ring_enchants,
   'finger_2' => ring_enchants,
   'main_hand' => weapon_enchants,
-  'off_hand' => weapon_enchants,
+  'off_hand' => off_hand_enchants,
 }
 
 TBC_GEM_QUALITY_MAPPING = {


### PR DESCRIPTION
Adds a shield-specific enchant whitelist for off-hand enchant checks.

Enchantment ids are from Wowhead TBC spell details:

- Major Stamina 1071 (spell 34009): https://www.wowhead.com/tbc/spell=34009/enchant-shield-major-stamina
- Resistance 1888 (spell 27947): https://www.wowhead.com/tbc/spell=27947/enchant-shield-resistance
- Tough Shield 2653 (spell 27944): https://www.wowhead.com/tbc/spell=27944/enchant-shield-tough-shield
- Intellect 2654 (spell 27945): https://www.wowhead.com/tbc/spell=27945/enchant-shield-intellect
- Shield Block 2655 (spell 27946): https://www.wowhead.com/tbc/spell=27946/enchant-shield-shield-block
- Resilience 3229 (spell 44383): https://www.wowhead.com/tbc/spell=44383/enchant-shield-resilience
